### PR TITLE
Read_A_Wishlist

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,13 +5,15 @@ Test cases for Wishlist Model
 import logging
 import unittest
 import os
-from service import app
+from service import app, status
 from service.models import Wishlist, Item, DataValidationError, db
 from tests.factories import WishlistFactory, ItemFactory
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/postgres"
 )
+
+BASE_URL = "/wishlists"
 
 ######################################################################
 #  W I S H L I S T   M O D E L   T E S T   C A S E S
@@ -114,7 +116,18 @@ class TestWishlist(unittest.TestCase):
         wishlists = Wishlist.all()
         self.assertEqual(len(wishlists), 5)
 
+    def test_read_a_wishlist(self):
+        """ Read a wishlist """
+        wishlist = self._create_wishlist()
+        wishlist.create()
 
+        # Read it back
+        found_wishlist = Wishlist.find(wishlist.id)
+        self.assertEqual(found_wishlist.id, wishlist.id)
+        self.assertEqual(found_wishlist.name, wishlist.name)
+        self.assertEqual(found_wishlist.user_id, wishlist.user_id)
+        self.assertEqual(found_wishlist.created_date, wishlist.created_date)
+        
     def test_serialize_an_wishlist(self):
         """ Serialize an wishlist """
         item = self._create_item()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -100,6 +100,11 @@ class TestWishlistService(TestCase):
         data = resp.get_json()
         self.assertEqual(data["name"], wishlist.name)
 
+    def test_get_wishlist_not_found(self):
+        """Get a Wishlist that is not found"""
+        resp = self.app.get(f"{BASE_URL}/0")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_create_wishlist(self):
         """ Create a new Wishlist """
         wishlist = WishlistFactory()
@@ -129,3 +134,33 @@ class TestWishlistService(TestCase):
         self.assertEqual(new_wishlist["items"], wishlist.items, "Item does not match")
         self.assertEqual(new_wishlist["user_id"], wishlist.user_id, "user_id does not match")
         self.assertEqual(new_wishlist["created_date"], str(wishlist.created_date), "Created Date does not match")
+    
+    # Error handler testing code below based on the Service_Accounts code example
+    def test_bad_request(self):
+        """ Send wrong media type """
+        wishlist = WishlistFactory()
+        resp = self.app.post(
+            BASE_URL, 
+            json={"name": "not enough data"}, 
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+    
+    def test_unsupported_media_type(self):
+        """ Send wrong media type """
+        wishlist = WishlistFactory()
+        resp = self.app.post(
+            BASE_URL, 
+            json=wishlist.serialize(), 
+            content_type="test/html"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+
+    def test_method_not_allowed(self):
+        """ Make an illegal method call """
+        resp = self.app.put(
+            BASE_URL, 
+            json={"not": "today"}, 
+            content_type="application/json"
+        )
+        self.assertEqual(resp.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)


### PR DESCRIPTION
Changes made:
- added test_read_a_wishlist method in test_model.py
- since get = read and our previous branch had the get_a_wishlist method, just added a get_wishlist_not_found method in test_routes.py
- also added the error handler testing code to improve the overall coverage